### PR TITLE
Removed 'install dependencies' from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 1.  Fork and clone this repository.
 1.  Change into the new directory.
-1.  Install dependencies.
 1.  Create and checkout a new branch, named `response`.
 1.  Follow the directions given in [diagnostic.md](diagnostic.md).
 1.  Before the alotted time is up, push to your fork and issue a pull request.


### PR DESCRIPTION
There are no dependencies or package.json file.
Removed this instruction from the README.
Fixes #58
